### PR TITLE
Fix: `mgh` support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     'pyrr',
     'pillow',
     'pyopengl',
+    'nibabel',
     'PyQt5'
 ]
 

--- a/whippersnappy/cli/whippersnap.py
+++ b/whippersnappy/cli/whippersnap.py
@@ -159,11 +159,13 @@ def run():
     parser.add_argument('--fthresh', type=float, default=2.0)
     parser.add_argument('-i', '--interactive', dest='interactive', action='store_true',
                         help='Start an interactive session.')
+    parser.add_argument('--invert', dest='invert', action='store_true',
+                        help='Invert the color scale.')
     args = parser.parse_args()
 
     if not args.interactive:
         snap4(args.lh_overlay, args.rh_overlay, sdir=args.sdir, caption=args.caption, surfname=args.surf_name,
-              fthresh=args.fthresh, fmax=args.fmax, invert=True, colorbar=True, outpath=args.output_path)
+              fthresh=args.fthresh, fmax=args.fmax, invert=args.invert, colorbar=True, outpath=args.output_path)
     else:
         current_fthresh_ = args.fthresh
         current_fmax_ = args.fmax

--- a/whippersnappy/cli/whippersnap.py
+++ b/whippersnappy/cli/whippersnap.py
@@ -153,7 +153,7 @@ def run():
     parser.add_argument('-o', '--output_path', type=str, default='/tmp/whippersnappy_snap.png',
                         help='Absolute path to the output file (snapshot image), '
                              'if not running interactive mode.')
-    parser.add_argument('-c', '--caption', type=str, default='Super cool WhipperSnapPy 2.0',
+    parser.add_argument('-c', '--caption', type=str, default='',
                         help='Caption to place on the figure')
     parser.add_argument('--fmax', type=float, default=4.0)
     parser.add_argument('--fthresh', type=float, default=2.0)

--- a/whippersnappy/cli/whippersnap.py
+++ b/whippersnappy/cli/whippersnap.py
@@ -163,7 +163,7 @@ def run():
 
     if not args.interactive:
         snap4(args.lh_overlay, args.rh_overlay, sdir=args.sdir, caption=args.caption, surfname=args.surf_name,
-              fthresh=args.fthresh, fmax=args.fmax, invert=False, colorbar=True, outpath=args.output_path)
+              fthresh=args.fthresh, fmax=args.fmax, invert=True, colorbar=True, outpath=args.output_path)
     else:
         current_fthresh_ = args.fthresh
         current_fmax_ = args.fmax

--- a/whippersnappy/core.py
+++ b/whippersnappy/core.py
@@ -22,7 +22,7 @@ import numpy as np
 from OpenGL.GL import *
 from PIL import Image, ImageDraw, ImageFont
 
-from .read_geometry import read_geometry, read_morph_data
+from .read_geometry import read_geometry, read_morph_data, read_mgh_data
 
 
 def normalize_mesh(v, scale=1.0):
@@ -295,7 +295,12 @@ def prepare_geometry(surfpath, overlaypath=None, curvpath=None, labelpath=None,
         sulcmap = 0.5 * np.ones(vertices.shape,dtype=np.float32)
     # read map (stats etc)
     if overlaypath:
-        mapdata = read_morph_data(overlaypath)
+        _, file_extension = os.path.splitext(overlaypath)
+
+        if file_extension == '.mgh':
+            mapdata = read_mgh_data(overlaypath)
+        else:
+            mapdata = read_morph_data(overlaypath)
         mapdata, fmin, fmax, neg = rescale_overlay(mapdata, minval, maxval)
         # mask map with label
         mapdata = mask_label(mapdata,labelpath)

--- a/whippersnappy/read_geometry.py
+++ b/whippersnappy/read_geometry.py
@@ -1,6 +1,7 @@
 # IMPORTS
 from collections import OrderedDict
 import numpy as np
+import nibabel as nib
 import warnings
 
 """
@@ -174,3 +175,23 @@ def read_morph_data(filepath):
             _fread3(fobj)
             curv = np.fromfile(fobj, '>i2', vnum) / 100
     return curv
+
+def read_mgh_data(filepath):
+    """Read an MGH image file and return its data array.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to mgh file
+
+    Returns
+    -------
+    data_array : numpy array
+        Image data array
+    """
+    data_array = np.array(nib.load(filepath).dataobj)
+
+    assert len(data_array.shape) == 3 and data_array.shape[1] == 1 and data_array.shape[2] == 1, \
+           'Expected data array to have shape Nx1x1. Instead, got {}'.format(data_array.shape)
+
+    return data_array.squeeze()


### PR DESCRIPTION
## Description

This PR mainly adds support for `mgh` overlay files, since the test-retest and group analysis files that we use are usually of this type.
If an `mgh` file is detected, `nibabel` is used to load the data. We expect the loaded data to be of shape Nx1x1; otherwise, an error is raised.

In addition, the defaults of the CLI were changed such that colors are inverted by default and no caption is added to the image.