### PR TITLE
Added handling of too few input arguments for surf

### DIFF
--- a/whippersnappy/core.py
+++ b/whippersnappy/core.py
@@ -789,14 +789,25 @@ def snap4(
             print(
                 "[INFO] No surf_name provided. Looking for options in surf directory..."
             )
+            
+            if sdir is None:
+                sdir = os.environ.get("SUBJECTS_DIR")
+                if not sdir:
+                    print(
+                        "[INFO] No surf_name or subjects directory (sdir) provided, can not find surf file"
+                    )
+                    sys.exit(1)
+                    
+            
             found_surfname = get_surf_name(sdir, hemi)
+            
             if found_surfname is None:
                 print(
                     "[ERROR] Could not find valid surf file in {} for hemi: {}!".format(
                         sdir, hemi
                     )
                 )
-                sys.exit(0)
+                sys.exit(1)
             meshpath = os.path.join(sdir, "surf", hemi + "." + found_surfname)
         else:
             meshpath = os.path.join(sdir, "surf", hemi + "." + surfname)

--- a/whippersnappy/core.py
+++ b/whippersnappy/core.py
@@ -794,8 +794,8 @@ def snap4(
                 sdir = os.environ.get("SUBJECTS_DIR")
                 if not sdir:
                     print(
-                        "[INFO] No surf_name or subjects directory (sdir) provided, \
-can not find surf file")
+                        "[INFO] No surf_name or subjects directory (sdir) provided, can not find surf file"
+                    )
                     sys.exit(1)
 
             found_surfname = get_surf_name(sdir, hemi)

--- a/whippersnappy/core.py
+++ b/whippersnappy/core.py
@@ -794,10 +794,9 @@ def snap4(
                 sdir = os.environ.get("SUBJECTS_DIR")
                 if not sdir:
                     print(
-                        "[INFO] No surf_name or subjects directory (sdir) provided, can not find surf file"
-                    )
+                        "[INFO] No surf_name or subjects directory (sdir) provided, \
+can not find surf file")
                     sys.exit(1)
-                    
             
             found_surfname = get_surf_name(sdir, hemi)
             

--- a/whippersnappy/core.py
+++ b/whippersnappy/core.py
@@ -789,7 +789,7 @@ def snap4(
             print(
                 "[INFO] No surf_name provided. Looking for options in surf directory..."
             )
-            
+
             if sdir is None:
                 sdir = os.environ.get("SUBJECTS_DIR")
                 if not sdir:
@@ -797,9 +797,9 @@ def snap4(
                         "[INFO] No surf_name or subjects directory (sdir) provided, \
 can not find surf file")
                     sys.exit(1)
-            
+
             found_surfname = get_surf_name(sdir, hemi)
-            
+
             if found_surfname is None:
                 print(
                     "[ERROR] Could not find valid surf file in {} for hemi: {}!".format(

--- a/whippersnappy/core.py
+++ b/whippersnappy/core.py
@@ -794,7 +794,8 @@ def snap4(
                 sdir = os.environ.get("SUBJECTS_DIR")
                 if not sdir:
                     print(
-                        "[INFO] No surf_name or subjects directory (sdir) provided, can not find surf file"
+                        "[INFO] No surf_name or subjects directory (sdir) \
+provided, can not find surf file"
                     )
                     sys.exit(1)
 


### PR DESCRIPTION
I ran into an issue where I tried to pass all default arguments and couldn't immediately figure out what I had to do to get an output. This was because I had neither specified an explicit surface path or a subject directory with fsaverage.

To improve this i added a fallback where we try to see if freesurfer is sourced and get the subjects directory from the environment. If that fails, we throw an error message.

I also added return codes that are not zero for failures.