### PR TITLE
Fix: Broken rotation keys

### DIFF
--- a/whippersnappy/cli/whippersnap.py
+++ b/whippersnappy/cli/whippersnap.py
@@ -140,13 +140,23 @@ def show_window(
         gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
 
         if app_window_ is not None:
-            if app_window_.get_fthresh_value() != current_fthresh_ or app_window_.get_fmax_value() != current_fmax_:
+            if (
+                app_window_.get_fthresh_value() != current_fthresh_
+                or app_window_.get_fmax_value() != current_fmax_
+            ):
                 current_fthresh_ = app_window_.get_fthresh_value()
                 current_fmax_ = app_window_.get_fmax_value()
                 meshdata, triangles, fthresh, fmax, neg = prepare_geometry(
-                    meshpath, overlaypath, curvpath, labelpath, current_fthresh_, current_fmax_
+                    meshpath,
+                    overlaypath,
+                    curvpath,
+                    labelpath,
+                    current_fthresh_,
+                    current_fmax_,
                 )
-                shader = setup_shader(meshdata, triangles, wwidth, wheight, specular=specular)
+                shader = setup_shader(
+                    meshdata, triangles, wwidth, wheight, specular=specular
+                )
 
         transformLoc = gl.glGetUniformLocation(shader, "transform")
         gl.glUniformMatrix4fv(transformLoc, 1, gl.GL_FALSE, rot_y * viewLeft)
@@ -274,7 +284,7 @@ def run():
         app_window_ = ConfigWindow(
             screen_dims=(screen_geometry.width(), screen_geometry.height()),
             initial_fthresh_value=current_fthresh_,
-            initial_fmax_value=current_fmax_
+            initial_fmax_value=current_fmax_,
         )
 
         # The following is a way to allow CTRL+C termination of the app:

--- a/whippersnappy/cli/whippersnap.py
+++ b/whippersnappy/cli/whippersnap.py
@@ -120,6 +120,11 @@ def show_window(
     # viewRight = rot_y * viewLeft
     rot_y = pyrr.Matrix44.from_y_rotation(0)
 
+    meshdata, triangles, fthresh, fmax, neg = prepare_geometry(
+        meshpath, overlaypath, curvpath, labelpath, current_fthresh_, current_fmax_
+    )
+    shader = setup_shader(meshdata, triangles, wwidth, wheight, specular=specular)
+
     print()
     print("Keys:")
     print("Left - Right : Rotate Geometry")
@@ -135,12 +140,13 @@ def show_window(
         gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
 
         if app_window_ is not None:
-            current_fthresh_ = app_window_.get_fthresh_value()
-            current_fmax_ = app_window_.get_fmax_value()
-        meshdata, triangles, fthresh, fmax, neg = prepare_geometry(
-            meshpath, overlaypath, curvpath, labelpath, current_fthresh_, current_fmax_
-        )
-        shader = setup_shader(meshdata, triangles, wwidth, wheight, specular=specular)
+            if app_window_.get_fthresh_value() != current_fthresh_ or app_window_.get_fmax_value() != current_fmax_:
+                current_fthresh_ = app_window_.get_fthresh_value()
+                current_fmax_ = app_window_.get_fmax_value()
+                meshdata, triangles, fthresh, fmax, neg = prepare_geometry(
+                    meshpath, overlaypath, curvpath, labelpath, current_fthresh_, current_fmax_
+                )
+                shader = setup_shader(meshdata, triangles, wwidth, wheight, specular=specular)
 
         transformLoc = gl.glGetUniformLocation(shader, "transform")
         gl.glUniformMatrix4fv(transformLoc, 1, gl.GL_FALSE, rot_y * viewLeft)
@@ -266,7 +272,9 @@ def run():
 
         screen_geometry = app.primaryScreen().availableGeometry()
         app_window_ = ConfigWindow(
-            screen_dims=(screen_geometry.width(), screen_geometry.height())
+            screen_dims=(screen_geometry.width(), screen_geometry.height()),
+            initial_fthresh_value=current_fthresh_,
+            initial_fmax_value=current_fmax_
         )
 
         # The following is a way to allow CTRL+C termination of the app:


### PR DESCRIPTION
## Description

This PR fixes an issue in the interaction between the config and GUI windows which prevented corrected handling of rotational key (left and right arrow) presses. The issue was reported in https://github.com/Deep-MI/WhipperSnapPy/issues/16.

Previously, the overlay `fthresh` and `fmax` values were continuosly updated in the GUi window while loop. Because of this, key button presses were almost always missed by the `glfw` functions.

Instead, these values are now updated only when inputs from the config window are changed.