### PR TITLE
Fix: Closing behaviour of interactive mode 

### DIFF
--- a/whippersnappy/cli/whippersnap.py
+++ b/whippersnappy/cli/whippersnap.py
@@ -44,6 +44,7 @@ from whippersnappy.core import (
 current_fthresh_ = None
 current_fmax_ = None
 app_window_ = None
+app_window_closed_ = False
 
 
 def show_window(
@@ -83,7 +84,7 @@ def show_window(
     -------
     None
     """
-    global current_fthresh_, current_fmax_, app_window_
+    global current_fthresh_, current_fmax_, app_window_, app_window_closed_
 
     wwidth = 720
     wheight = 600
@@ -130,6 +131,11 @@ def show_window(
     while glfw.get_key(
         window, glfw.KEY_ESCAPE
     ) != glfw.PRESS and not glfw.window_should_close(window):
+
+        # Terminate if config app window was closed:
+        if app_window_closed_:
+            break
+
         glfw.poll_events()
 
         gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
@@ -157,6 +163,11 @@ def show_window(
         glfw.swap_buffers(window)
 
     glfw.terminate()
+
+
+def config_app_exit_handler():
+    global app_window_closed_
+    app_window_closed_ = True
 
 
 def run():
@@ -263,6 +274,7 @@ def run():
         # Setting up and running config app window (must be main thread):
         app = QApplication([])
         app.setStyle("Fusion")  # the default
+        app.aboutToQuit.connect(config_app_exit_handler)
 
         screen_geometry = app.primaryScreen().availableGeometry()
         app_window_ = ConfigWindow(

--- a/whippersnappy/cli/whippersnap.py
+++ b/whippersnappy/cli/whippersnap.py
@@ -132,7 +132,6 @@ def show_window(
     while glfw.get_key(
         window, glfw.KEY_ESCAPE
     ) != glfw.PRESS and not glfw.window_should_close(window):
-
         # Terminate if config app window was closed:
         if app_window_closed_:
             break

--- a/whippersnappy/cli/whippersnap.py
+++ b/whippersnappy/cli/whippersnap.py
@@ -43,6 +43,7 @@ from whippersnappy.core import (
 # Global variables for config app configuration state:
 current_fthresh_ = None
 current_fmax_ = None
+app_ = None
 app_window_ = None
 app_window_closed_ = False
 
@@ -84,7 +85,7 @@ def show_window(
     -------
     None
     """
-    global current_fthresh_, current_fmax_, app_window_, app_window_closed_
+    global current_fthresh_, current_fmax_, app_, app_window_, app_window_closed_
 
     wwidth = 720
     wheight = 600
@@ -163,6 +164,7 @@ def show_window(
         glfw.swap_buffers(window)
 
     glfw.terminate()
+    app_.quit()
 
 
 def config_app_exit_handler():
@@ -171,7 +173,7 @@ def config_app_exit_handler():
 
 
 def run():
-    global current_fthresh_, current_fmax_, app_window_
+    global current_fthresh_, current_fmax_, app_, app_window_
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -272,11 +274,11 @@ def run():
         thread.start()
 
         # Setting up and running config app window (must be main thread):
-        app = QApplication([])
-        app.setStyle("Fusion")  # the default
-        app.aboutToQuit.connect(config_app_exit_handler)
+        app_ = QApplication([])
+        app_.setStyle("Fusion")  # the default
+        app_.aboutToQuit.connect(config_app_exit_handler)
 
-        screen_geometry = app.primaryScreen().availableGeometry()
+        screen_geometry = app_.primaryScreen().availableGeometry()
         app_window_ = ConfigWindow(
             screen_dims=(screen_geometry.width(), screen_geometry.height())
         )
@@ -285,7 +287,7 @@ def run():
         signal.signal(signal.SIGINT, signal.SIG_DFL)
 
         app_window_.show()
-        app.exec()
+        app_.exec()
 
 
 # headless docker test using xvfb:

--- a/whippersnappy/config_app.py
+++ b/whippersnappy/config_app.py
@@ -262,3 +262,10 @@ class ConfigWindow(QWidget):
             Current fmax value
         """
         return self.current_fmax_value
+
+    def keyPressEvent(self, event):
+        """
+        Closes the window when ESC is pressed.
+        """
+        if event.key() == Qt.Key_Escape:
+            self.close()


### PR DESCRIPTION
## Description

This PR addresses the issue reported in https://github.com/Deep-MI/WhipperSnapPy/issues/17.

As a result, both the GUI and config windows are closed if either is closed (by clicking the window exit button or pressing the ESC key).