### PR TITLE
Fix: OpenGL version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     'numpy>=1.21',
     'pyrr',
     'pillow',
-    'pyopengl',
+    'pyopengl==3.1.6',
     'nibabel',
     'PyQt5',
     'psutil'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     'pillow',
     'pyopengl==3.1.6',
     'nibabel',
-    'PyQt5',
+    'PyQt5==5.15.6',
     'psutil'
 ]
 


### PR DESCRIPTION
## Description

The `pyopengl` dependency version to install when installing `WhipperSnapPy` was previously unspecified. When using the tool in our FastSurfer validation pipeline, this lead to installing an untested OpenGL version (3.1.7), which caused the following error due to an import within [core.py](https://github.com/Deep-MI/WhipperSnapPy/blob/5362e4606f7037c91b3e9b5671bbe2f9fd1e8344/whippersnappy/core.py#L18):
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/venv/lib/python3.8/site-packages/OpenGL/GL/__init__.py", line 4, in <module>
    from OpenGL.GL.VERSION.GL_1_1 import *
  File "/venv/lib/python3.8/site-packages/OpenGL/GL/VERSION/GL_1_1.py", line 14, in <module>
    from OpenGL.raw.GL.VERSION.GL_1_1 import *
  File "/venv/lib/python3.8/site-packages/OpenGL/raw/GL/VERSION/GL_1_1.py", line 7, in <module>
    from OpenGL.raw.GL import _errors
  File "/venv/lib/python3.8/site-packages/OpenGL/raw/GL/_errors.py", line 4, in <module>
    _error_checker = _ErrorChecker( _p, _p.GL.glGetError )
AttributeError: 'NoneType' object has no attribute 'glGetError'
```

This PR fixes the `pyopengl` and `PyQt5` dependencies to the validated versions (`3.1.6` and `5.15.6`, respectively).