### PR TITLE
Added vertical colorbar and caption support for snap1 and fixed invisible caption issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ dmypy.json
 
 # PyCharm
 **/.idea/
+
+# uv
+uv.lock


### PR DESCRIPTION
This PR adds an optional argument to the snap1 function that allows for the orientation of the colorbar and caption to be controlled.

<img width="860" height="360" alt="image" src="https://github.com/user-attachments/assets/7a782675-34a0-4742-8c0f-3ecfc2d7b533" />

This PR also fixes a bug in the original horizontal implementation that led to the caption being occluded by the colorbar.